### PR TITLE
Add ClassConstantsMustHaveVisibilityRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Run tests using PHPUnit:
 vendor/bin/phpunit -c tests/phpunit.xml tests
 ```
 
+Run static analysis with PHPStan:
+```bash
+vendor/bin/phpstan analyse src tests -l 5
+```
+
 ## Use in a project
 
 To use this extension, first require it in [Composer](https://getcomposer.org/):

--- a/extension.neon
+++ b/extension.neon
@@ -5,3 +5,8 @@ services:
 			configurationFileLoader: @strictTypesForNewClassesRuleConfigurationFileLoader
 		tags:
 			- phpstan.rules.rule
+
+	ClassConstantsMustHaveVisibilityRule:
+		class: PHPStanForPrestaShop\Rules\ClassConstantsMustHaveVisibilityRule
+		tags:
+			- phpstan.rules.rule

--- a/src/Rules/ClassConstantsMustHaveVisibilityRule.php
+++ b/src/Rules/ClassConstantsMustHaveVisibilityRule.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStanForPrestaShop\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassConst;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class ClassConstantsMustHaveVisibilityRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return ClassConst::class;
+    }
+
+    /**
+     * @param ClassConst $node
+     * @param Scope $scope
+     *
+     * @return array
+     *
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $constantDeclaresVisibility = (($node->flags & Node\Stmt\Class_::VISIBILITY_MODIFIER_MASK) !== 0);
+
+        if (!$constantDeclaresVisibility) {
+            return [
+                RuleErrorBuilder::message(
+                    sprintf(
+                        'Class constant %s must declare a visibility',
+                        $node->consts[0]->name
+                    )
+                )->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/tests/Rules/ClassConstantsMustHaveVisibilityRuleTest.php
+++ b/tests/Rules/ClassConstantsMustHaveVisibilityRuleTest.php
@@ -30,7 +30,10 @@ class ClassConstantsMustHaveVisibilityRuleTest extends RuleTestCase
             [$dataDirectory . 'ClassBWithPublicConstant.php'], []
         );
         $this->analyse(
-            [$dataDirectory . 'ClassCWithProtectedConstant.php'], []
+            [$dataDirectory . 'ClassCWithPrivateConstant.php'], []
+        );
+        $this->analyse(
+            [$dataDirectory . 'ClassDWithProtectedConstant.php'], []
         );
     }
 }

--- a/tests/Rules/ClassConstantsMustHaveVisibilityRuleTest.php
+++ b/tests/Rules/ClassConstantsMustHaveVisibilityRuleTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace PHPStanForPrestaShopTests\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStanForPrestaShop\PHPConfigurationLoader\ArrayConfigurationLoader;
+use PHPStanForPrestaShop\Rules\ClassConstantsMustHaveVisibilityRule;
+use PHPStanForPrestaShop\Rules\UseStrictTypesForNewClassesRule;
+
+class ClassConstantsMustHaveVisibilityRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ClassConstantsMustHaveVisibilityRule();
+    }
+
+    public function testRule(): void
+    {
+        $dataDirectory = __DIR__ . '/../data/';
+
+        $this->analyse(
+            [$dataDirectory . 'ClassAWithUnscopedConstant.php'], [
+            [
+                'Class constant FOO must declare a visibility',
+                7,
+            ],
+        ]);
+        $this->analyse(
+            [$dataDirectory . 'ClassBWithPublicConstant.php'], []
+        );
+        $this->analyse(
+            [$dataDirectory . 'ClassCWithProtectedConstant.php'], []
+        );
+    }
+}

--- a/tests/data/ClassAWithUnscopedConstant.php
+++ b/tests/data/ClassAWithUnscopedConstant.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Space;
+
+class A
+{
+    const FOO = 1;
+}

--- a/tests/data/ClassBWithPublicConstant.php
+++ b/tests/data/ClassBWithPublicConstant.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Space;
+
+class B
+{
+    public const FOO = 1;
+}

--- a/tests/data/ClassCWithPrivateConstant.php
+++ b/tests/data/ClassCWithPrivateConstant.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Space;
+
+class C
+{
+    private const FOO = 1;
+}

--- a/tests/data/ClassCWithProtectedConstant.php
+++ b/tests/data/ClassCWithProtectedConstant.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Space;
+
+class C
+{
+    protected const FOO = 1;
+}

--- a/tests/data/ClassDWithProtectedConstant.php
+++ b/tests/data/ClassDWithProtectedConstant.php
@@ -2,7 +2,7 @@
 
 namespace Space;
 
-class C
+class D
 {
     protected const FOO = 1;
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add ClassConstantsMustHaveVisibilityRule. This rule requires class constants to have a declared visibility.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | One item of https://github.com/PrestaShop/PrestaShop/issues/22728
| How to test?      | CI is green
| Possible impacts? |

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
