### PR TITLE
Introduce UseTypeHintForNewMethodsRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ the `UseStrictTypesForNewClassesRule` should not be applied.
 There is two available implementations: `PHPStanForPrestaShop\PHPConfigurationLoader\ArrayConfigurationLoader`
 and `PHPStanForPrestaShop\PHPConfigurationLoader\PHPConfigurationFileLoader`.
 
-Example with PHPConfigurationFileLoader:
+Example with `PHPConfigurationFileLoader`:
 
 ```neon
 services:
-	strictTypesForNewClassesRuleConfigurationFileLoader:
-		class: PHPStanForPrestaShop\PHPConfigurationLoader\PHPConfigurationFileLoader
-		arguments:
-			- .github/workflows/phpstan/exclude-class-list.php
+    strictTypesForNewClassesRuleConfigurationFileLoader:
+        class: PHPStanForPrestaShop\PHPConfigurationLoader\PHPConfigurationFileLoader
+        arguments:
+            - .github/workflows/phpstan/exclude-class-list.php
 ```
 
 #### UseTypedReturnForNewMethodsRule
@@ -92,14 +92,14 @@ the `UseTypedReturnForNewMethodsRule` should not be applied.
 There is two available implementations: `PHPStanForPrestaShop\PHPConfigurationLoader\ArrayConfigurationLoader`
 and `PHPStanForPrestaShop\PHPConfigurationLoader\PHPConfigurationFileLoader`.
 
-Example with PHPConfigurationFileLoader:
+Example with `PHPConfigurationFileLoader`:
 
 ```neon
 services:
-	returnTypesForNewMethodsRuleConfigurationFileLoader:
-		class: PHPStanForPrestaShop\PHPConfigurationLoader\PHPConfigurationFileLoader
-		arguments:
-			- .github/workflows/phpstan/exclude-return-functions-list.php
+    returnTypesForNewMethodsRuleConfigurationFileLoader:
+        class: PHPStanForPrestaShop\PHPConfigurationLoader\PHPConfigurationFileLoader
+        arguments:
+            - .github/workflows/phpstan/exclude-return-functions-list.php
 ```
 
 #### UseTypeHintForNewMethodsRule

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
 * [PHPStan](https://phpstan.org/)
 * [PrestaShop](https://github.com/prestashop/prestashop)
 
+## Content
+
+This PHPStan extension adds custom rules to PHPStan:
+
+- ClassConstantsMustHaveVisibilityRule
+- UseStrictTypesForNewClassesRule
+- UseTypeHintForNewMethodsRule
+- UseTypedReturnForNewMethodsRule
+
 ## Installation
 
 Install the dependencies with [Composer](https://getcomposer.org/):
@@ -26,6 +35,8 @@ Run tests using PHPUnit:
 ```bash
 vendor/bin/phpunit -c tests/phpunit.xml tests
 ```
+
+Rules are tested using PHPStan [RuleTestCase](https://github.com/phpstan/phpstan-src/blob/master/src/Testing/RuleTestCase.php).
 
 Run static analysis with PHPStan:
 ```bash
@@ -89,4 +100,23 @@ services:
 		class: PHPStanForPrestaShop\PHPConfigurationLoader\PHPConfigurationFileLoader
 		arguments:
 			- .github/workflows/phpstan/exclude-return-functions-list.php
+```
+
+#### UseTypeHintForNewMethodsRule
+
+Similarly to `UseTypedReturnForNewMethodsRule`, rule `UseTypeHintForNewMethodsRule` requires loading of an instance of `PHPStanForPrestaShop\PHPConfigurationLoader\ConfigurationLoaderInterface`,
+named `@typeHintsForNewMethodsRuleConfigurationFileLoader`. It should load an array of class methods for which
+the `UseTypeHintForNewMethodsRule` should not be applied.
+
+There is two available implementations: `PHPStanForPrestaShop\PHPConfigurationLoader\ArrayConfigurationLoader`
+and `PHPStanForPrestaShop\PHPConfigurationLoader\PHPConfigurationFileLoader`.
+
+Example with PHPConfigurationFileLoader:
+
+```neon
+services:
+	typeHintsForNewMethodsRuleConfigurationFileLoader:
+		class: PHPStanForPrestaShop\PHPConfigurationLoader\PHPConfigurationFileLoader
+		arguments:
+			- .github/workflows/phpstan/exclude-typehint-functions-list.php
 ```

--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ the `UseTypeHintForNewMethodsRule` should not be applied.
 There is two available implementations: `PHPStanForPrestaShop\PHPConfigurationLoader\ArrayConfigurationLoader`
 and `PHPStanForPrestaShop\PHPConfigurationLoader\PHPConfigurationFileLoader`.
 
-Example with PHPConfigurationFileLoader:
+Example with `PHPConfigurationFileLoader`:
 
 ```neon
 services:
-	typeHintsForNewMethodsRuleConfigurationFileLoader:
-		class: PHPStanForPrestaShop\PHPConfigurationLoader\PHPConfigurationFileLoader
-		arguments:
-			- .github/workflows/phpstan/exclude-typehint-functions-list.php
+    typeHintsForNewMethodsRuleConfigurationFileLoader:
+        class: PHPStanForPrestaShop\PHPConfigurationLoader\PHPConfigurationFileLoader
+        arguments:
+            - .github/workflows/phpstan/exclude-typehint-functions-list.php
 ```

--- a/extension.neon
+++ b/extension.neon
@@ -1,26 +1,26 @@
 services:
-	UseStrictTypesForNewClassesRule:
-		class: PHPStanForPrestaShop\Rules\UseStrictTypesForNewClassesRule
-		arguments:
-			configurationFileLoader: @strictTypesForNewClassesRuleConfigurationFileLoader
-		tags:
-			- phpstan.rules.rule
+    UseStrictTypesForNewClassesRule:
+        class: PHPStanForPrestaShop\Rules\UseStrictTypesForNewClassesRule
+        arguments:
+            configurationFileLoader: @strictTypesForNewClassesRuleConfigurationFileLoader
+        tags:
+            - phpstan.rules.rule
 
-	ClassConstantsMustHaveVisibilityRule:
-		class: PHPStanForPrestaShop\Rules\ClassConstantsMustHaveVisibilityRule
-		tags:
-			- phpstan.rules.rule
+    ClassConstantsMustHaveVisibilityRule:
+        class: PHPStanForPrestaShop\Rules\ClassConstantsMustHaveVisibilityRule
+        tags:
+            - phpstan.rules.rule
 
-	UseTypedReturnForNewMethodsRule:
-		class: PHPStanForPrestaShop\Rules\UseTypedReturnForNewMethodsRule
-		arguments:
-			configurationFileLoader: @returnTypesForNewMethodsRuleConfigurationFileLoader
-		tags:
-			- phpstan.rules.rule
+    UseTypedReturnForNewMethodsRule:
+    class: PHPStanForPrestaShop\Rules\UseTypedReturnForNewMethodsRule
+        arguments:
+            configurationFileLoader: @returnTypesForNewMethodsRuleConfigurationFileLoader
+        tags:
+            - phpstan.rules.rule
 
     UseTypeHintForNewMethodsRule:
-		class: PHPStanForPrestaShop\Rules\UseTypeHintForNewMethodsRule
-		arguments:
-			configurationFileLoader: @typeHintsForNewMethodsRuleConfigurationFileLoader
-		tags:
-			- phpstan.rules.rule
+        class: PHPStanForPrestaShop\Rules\UseTypeHintForNewMethodsRule
+        arguments:
+            configurationFileLoader: @typeHintsForNewMethodsRuleConfigurationFileLoader
+        tags:
+            - phpstan.rules.rule

--- a/extension.neon
+++ b/extension.neon
@@ -17,3 +17,10 @@ services:
 			configurationFileLoader: @returnTypesForNewMethodsRuleConfigurationFileLoader
 		tags:
 			- phpstan.rules.rule
+
+    UseTypeHintForNewMethodsRule:
+		class: PHPStanForPrestaShop\Rules\UseTypeHintForNewMethodsRule
+		arguments:
+			configurationFileLoader: @typeHintsForNewMethodsRuleConfigurationFileLoader
+		tags:
+			- phpstan.rules.rule

--- a/src/Rules/UseTypeHintForNewMethodsRule.php
+++ b/src/Rules/UseTypeHintForNewMethodsRule.php
@@ -1,0 +1,118 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PHPStanForPrestaShop\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStanForPrestaShop\PHPConfigurationLoader\ConfigurationLoaderInterface;
+
+/**
+ * @implements Rule<Node\Stmt\ClassMethod>
+ */
+class UseTypeHintForNewMethodsRule implements Rule
+{
+    /** @var array */
+    private $excludedClassMethodsList;
+
+    /**
+     * @param ConfigurationLoaderInterface $configurationFileLoader
+     */
+    public function __construct(ConfigurationLoaderInterface $configurationFileLoader)
+    {
+        $this->excludedClassMethodsList = $configurationFileLoader->load();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     * @param Scope $scope
+     *
+     * @return array
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $className = $scope->getClassReflection()->getName();
+        $fullMethodName = $className . '::' . $node->name;
+        if (in_array($fullMethodName, $this->excludedClassMethodsList)) {
+            return [];
+        }
+
+        $notTypedParameters = $this->findNotTypedParameters($node);
+
+        if (empty($notTypedParameters)) {
+            return [];
+        }
+
+        $parentClassNames = $scope->getClassReflection()->getParentClassesNames();
+        if (empty($parentClassNames)) {
+            // class method does not use typed hints and has no parents, it's a rule violation
+            return [
+                RuleErrorBuilder::message($this->buildErrorMessage($node->name->name, $notTypedParameters))
+                    ->build(),
+            ];
+        }
+
+        foreach ($parentClassNames as $parentClassName) {
+            $fullParentMethodName = $parentClassName . '::' . $node->name;
+            if (in_array($fullParentMethodName, $this->excludedClassMethodsList)) {
+                return [];
+            }
+        }
+
+        return [
+            RuleErrorBuilder::message($this->buildErrorMessage($node->name->name, $notTypedParameters))
+                ->build(),
+        ];
+    }
+
+    /**
+     * @param string $functionName
+     * @param array $notTypedParameters
+     *
+     * @return string
+     */
+    private function buildErrorMessage(string $functionName, array $notTypedParameters)
+    {
+        return sprintf('Every parameter of function %s should be type hinted ' .
+            '(untyped parameters: %s).',
+            $functionName,
+            implode(',', $notTypedParameters)
+        );
+    }
+
+    /**
+     * @param ClassMethod $node
+     *
+     * @return array
+     */
+    private function findNotTypedParameters(ClassMethod $node): array
+    {
+        $notTypedParameters = [];
+
+        foreach ($node->getParams() as $parameter) {
+            if ($parameter->type === null) {
+                $notTypedParameters[] = $parameter->var->name;
+            }
+        }
+        return $notTypedParameters;
+    }
+}

--- a/src/Rules/UseTypeHintForNewMethodsRule.php
+++ b/src/Rules/UseTypeHintForNewMethodsRule.php
@@ -95,7 +95,7 @@ class UseTypeHintForNewMethodsRule implements Rule
         return sprintf('Every parameter of function %s should be type hinted ' .
             '(untyped parameters: %s).',
             $functionName,
-            implode(',', $notTypedParameters)
+            implode(', ', $notTypedParameters)
         );
     }
 

--- a/tests/Data/UseTypeHintForNewMethods/F.php
+++ b/tests/Data/UseTypeHintForNewMethods/F.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods;
+
+class F
+{
+    public function bar($a, $b)
+    {
+        return 'hello world';
+    }
+}

--- a/tests/Data/UseTypeHintForNewMethods/MethodFooAWithoutTypeHint.php
+++ b/tests/Data/UseTypeHintForNewMethods/MethodFooAWithoutTypeHint.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods;
+
+class MethodFooAWithoutTypeHint
+{
+    public function foo($a)
+    {
+        return 'hello world';
+    }
+}

--- a/tests/Data/UseTypeHintForNewMethods/MethodFooAWithoutTypeHint.php
+++ b/tests/Data/UseTypeHintForNewMethods/MethodFooAWithoutTypeHint.php
@@ -10,7 +10,7 @@ namespace PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods;
 
 class MethodFooAWithoutTypeHint
 {
-    public function foo($a)
+    public function foo($a, $z)
     {
         return 'hello world';
     }

--- a/tests/Data/UseTypeHintForNewMethods/MethodFooBOneParameterWithTypeHint.php
+++ b/tests/Data/UseTypeHintForNewMethods/MethodFooBOneParameterWithTypeHint.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods;
+
+class MethodFooBOneParameterWithTypeHint
+{
+    public function foo(string $b)
+    {
+        return sprintf('hello world %s', $b);
+    }
+}

--- a/tests/Data/UseTypeHintForNewMethods/MethodFooCOneParameterWithTypeHintAndOneWithout.php
+++ b/tests/Data/UseTypeHintForNewMethods/MethodFooCOneParameterWithTypeHintAndOneWithout.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods;
+
+class MethodFooCOneParameterWithTypeHintAndOneWithout
+{
+    public function foo(string $c, $d)
+    {
+        return sprintf('hello world %s', $c);
+    }
+}

--- a/tests/Data/UseTypeHintForNewMethods/MethodFooDFourParametersWithScalarTypeHint.php
+++ b/tests/Data/UseTypeHintForNewMethods/MethodFooDFourParametersWithScalarTypeHint.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods;
+
+class MethodFooDFourParametersWithScalarTypeHint
+{
+    public function foo(string $a, int $b, ?array $c, bool $e)
+    {
+        return sprintf('hello world %s', $b);
+    }
+}

--- a/tests/Data/UseTypeHintForNewMethods/MethodFooEThreeParametersWithIdentifierTypeHint.php
+++ b/tests/Data/UseTypeHintForNewMethods/MethodFooEThreeParametersWithIdentifierTypeHint.php
@@ -1,0 +1,19 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods;
+
+use DateTime;
+
+class MethodFooEThreeParametersWithIdentifierTypeHint
+{
+    public function foo(MethodFooAWithoutTypeHint $a, DateTime $b, ?DateTime $c)
+    {
+        return sprintf('hello world %s', $b->format('Y-m-d'));
+    }
+}

--- a/tests/Data/UseTypeHintForNewMethods/MethodFooGWithoutTypeHintButExcluded.php
+++ b/tests/Data/UseTypeHintForNewMethods/MethodFooGWithoutTypeHintButExcluded.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods;
+
+class MethodFooGWithoutTypeHintButExcluded
+{
+    public function foo($a, $b, $c)
+    {
+        return sprintf('hello world %s', $b);
+    }
+}

--- a/tests/Data/UseTypeHintForNewMethods/MethodFooHWithoutTypeHintButExtendsAnExcludedClass.php
+++ b/tests/Data/UseTypeHintForNewMethods/MethodFooHWithoutTypeHintButExtendsAnExcludedClass.php
@@ -1,0 +1,19 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods;
+
+use PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods\F;
+
+class MethodFooHWithoutTypeHintButExtendsAnExcludedClass extends F
+{
+    public function foo($a, $b)
+    {
+        return sprintf('hello world %s', $b);
+    }
+}

--- a/tests/Rules/UseTypeHintForNewMethodsRuleTest.php
+++ b/tests/Rules/UseTypeHintForNewMethodsRuleTest.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PHPStanForPrestaShopTests\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStanForPrestaShop\PHPConfigurationLoader\ArrayConfigurationLoader;
+use PHPStanForPrestaShop\Rules\UseTypedReturnForNewMethodsRule;
+use PHPStanForPrestaShop\Rules\UseTypeHintForNewMethodsRule;
+
+class UseTypeHintForNewMethodsRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        $configurationLoader = new ArrayConfigurationLoader([
+            'D::bar',
+            'PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods\MethodFooGWithoutTypeHintButExcluded::foo',
+            'PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods\F::foo',
+        ]);
+
+        return new UseTypeHintForNewMethodsRule($configurationLoader);
+    }
+
+    public function testRule(): void
+    {
+        $dataDirectory = __DIR__ . '/../Data/UseTypeHintForNewMethods/';
+
+        $this->analyse(
+            [$dataDirectory . 'MethodFooAWithoutTypeHint.php'], [
+            [
+                'Every parameter of function foo should be type hinted (untyped parameters: a).',
+                13,
+            ],
+        ]);
+
+        $this->analyse([$dataDirectory . 'MethodFooBOneParameterWithTypeHint.php'], []);
+
+        $this->analyse(
+            [$dataDirectory . 'MethodFooCOneParameterWithTypeHintAndOneWithout.php'], [
+            [
+                'Every parameter of function foo should be type hinted (untyped parameters: d).',
+                13,
+            ],
+        ]);
+
+        $this->analyse([$dataDirectory . 'MethodFooDFourParametersWithScalarTypeHint.php'], []);
+        $this->analyse([$dataDirectory . 'MethodFooEThreeParametersWithIdentifierTypeHint.php'], []);
+        $this->analyse([$dataDirectory . 'MethodFooGWithoutTypeHintButExcluded.php'], []);
+        $this->analyse([$dataDirectory . 'MethodFooHWithoutTypeHintButExtendsAnExcludedClass.php'], []);
+    }
+}

--- a/tests/Rules/UseTypeHintForNewMethodsRuleTest.php
+++ b/tests/Rules/UseTypeHintForNewMethodsRuleTest.php
@@ -36,7 +36,7 @@ class UseTypeHintForNewMethodsRuleTest extends RuleTestCase
         $this->analyse(
             [$dataDirectory . 'MethodFooAWithoutTypeHint.php'], [
             [
-                'Every parameter of function foo should be type hinted (untyped parameters: a).',
+                'Every parameter of function foo should be type hinted (untyped parameters: a, z).',
                 13,
             ],
         ]);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Introduce UseTypeHintForNewMethodsRule. This rule asserts than any new class method must typehint _all parameters_. Exclusions to this rule can be provided through a configuration array, similarly to UseStrictTypesForNewClassesRule.<br/><br/>Also UseTypedReturnForNewMethodsRule looks for inheritance: if class `A` extends `B` and `B::bar()` is part of the exclusion list, then `A::bar()` will be excluded too.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 1 item of https://github.com/PrestaShop/PrestaShop/issues/22728
| How to test?      | CI should pass
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
