### PR TITLE
Handle multiple loads of same file through PHPConfigurationFileLoader

### DIFF
--- a/src/PHPConfigurationLoader/PHPConfigurationFileLoader.php
+++ b/src/PHPConfigurationLoader/PHPConfigurationFileLoader.php
@@ -35,7 +35,7 @@ class PHPConfigurationFileLoader implements ConfigurationLoaderInterface
     public function load(): array
     {
         if ($this->configurationCache === null) {
-            $this->configurationCache = require_once $this->filepath;
+            $this->configurationCache = require $this->filepath;
         }
 
         return $this->configurationCache;

--- a/tests/PHPConfigurationLoader/PHPConfigurationFileLoaderTest.php
+++ b/tests/PHPConfigurationLoader/PHPConfigurationFileLoaderTest.php
@@ -36,7 +36,7 @@ class PHPConfigurationFileLoaderTest extends TestCase
         $loader = new PHPConfigurationFileLoader(__DIR__ . '/../Data/a.php');
     }
 
-        public function testLoadTwiceTheSameFile()
+    public function testLoadTwiceTheSameFile()
     {
         $loader1 = new PHPConfigurationFileLoader(__DIR__ . '/../Data/dummyConfigurationFile.php');
 

--- a/tests/PHPConfigurationLoader/PHPConfigurationFileLoaderTest.php
+++ b/tests/PHPConfigurationLoader/PHPConfigurationFileLoaderTest.php
@@ -35,4 +35,14 @@ class PHPConfigurationFileLoaderTest extends TestCase
 
         $loader = new PHPConfigurationFileLoader(__DIR__ . '/../Data/a.php');
     }
+
+        public function testLoadTwiceTheSameFile()
+    {
+        $loader1 = new PHPConfigurationFileLoader(__DIR__ . '/../Data/dummyConfigurationFile.php');
+
+        $loader2 = new PHPConfigurationFileLoader(__DIR__ . '/../Data/dummyConfigurationFile.php');
+
+        $this->assertEquals(['abc'], $loader1->load());
+        $this->assertEquals(['abc'], $loader2->load());
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | PHPConfigurationFileLoader was not able to handle multiple loads of same file because of `require_once`. I fix it and add the failing test.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI is happy
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
