### PR TITLE
Exclude class methods with inheritdoc for Type rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "phpstan/phpstan-phpunit": "^0.12.16",
     "phpstan/phpstan-strict-rules": "^0.12.5",
     "phpunit/phpunit": "^7.5.20",
-    "symfony/console": "^5.2"
+    "symfony/console": "^5.2",
+    "nikic/php-parser": "^4.10"
   },
   "extra": {
     "branch-alias": {

--- a/extension.neon
+++ b/extension.neon
@@ -1,4 +1,7 @@
 services:
+    PhpDocAnalyzer:
+        class: PHPStanForPrestaShop\PhpDoc\PhpDocAnalyzer
+
     UseStrictTypesForNewClassesRule:
         class: PHPStanForPrestaShop\Rules\UseStrictTypesForNewClassesRule
         arguments:
@@ -15,6 +18,7 @@ services:
         class: PHPStanForPrestaShop\Rules\UseTypedReturnForNewMethodsRule
         arguments:
             configurationFileLoader: @returnTypesForNewMethodsRuleConfigurationFileLoader
+            PhpDocAnalyzer: @PhpDocAnalyzer
         tags:
             - phpstan.rules.rule
 
@@ -22,5 +26,6 @@ services:
         class: PHPStanForPrestaShop\Rules\UseTypeHintForNewMethodsRule
         arguments:
             configurationFileLoader: @typeHintsForNewMethodsRuleConfigurationFileLoader
+            PhpDocAnalyzer: @PhpDocAnalyzer
         tags:
             - phpstan.rules.rule

--- a/src/PhpDoc/PhpDocAnalyzer.php
+++ b/src/PhpDoc/PhpDocAnalyzer.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PHPStanForPrestaShop\PhpDoc;
+
+use PhpParser\Comment\Doc;
+
+class PhpDocAnalyzer
+{
+    public function containsInheritDocTag(Doc $docComment): bool
+    {
+        return ((strpos($docComment->getText(), '{@inheritdoc}') !== false)
+            || (strpos($docComment->getText(), '{@inheritDoc}') !== false));
+    }
+}

--- a/src/Rules/UseTypeHintForNewMethodsRule.php
+++ b/src/Rules/UseTypeHintForNewMethodsRule.php
@@ -16,6 +16,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStanForPrestaShop\PHPConfigurationLoader\ConfigurationLoaderInterface;
+use PHPStanForPrestaShop\PhpDoc\PhpDocAnalyzer;
 
 /**
  * @implements Rule<Node\Stmt\ClassMethod>
@@ -25,12 +26,17 @@ class UseTypeHintForNewMethodsRule implements Rule
     /** @var array */
     private $excludedClassMethodsList;
 
+    /** @var PhpDocAnalyzer */
+    private $phpDocAnalyzer;
+
     /**
      * @param ConfigurationLoaderInterface $configurationFileLoader
+     * @param PhpDocAnalyzer $phpDocAnalyzer
      */
-    public function __construct(ConfigurationLoaderInterface $configurationFileLoader)
+    public function __construct(ConfigurationLoaderInterface $configurationFileLoader, PhpDocAnalyzer $phpDocAnalyzer)
     {
         $this->excludedClassMethodsList = $configurationFileLoader->load();
+        $this->phpDocAnalyzer = $phpDocAnalyzer;
     }
 
     /**
@@ -51,6 +57,11 @@ class UseTypeHintForNewMethodsRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         if ($node->isMagic()) {
+            return [];
+        }
+
+        $docComment = $node->getDocComment();
+        if (null !== $docComment && $this->phpDocAnalyzer->containsInheritDocTag($docComment)) {
             return [];
         }
 

--- a/src/Rules/UseTypedReturnForNewMethodsRule.php
+++ b/src/Rules/UseTypedReturnForNewMethodsRule.php
@@ -16,6 +16,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStanForPrestaShop\PHPConfigurationLoader\ConfigurationLoaderInterface;
+use PHPStanForPrestaShop\PhpDoc\PhpDocAnalyzer;
 
 /**
  * @implements Rule<Node\Stmt\ClassMethod>
@@ -25,12 +26,17 @@ class UseTypedReturnForNewMethodsRule implements Rule
     /** @var array */
     private $excludedClassMethodsList;
 
+    /** @var PhpDocAnalyzer */
+    private $phpDocAnalyzer;
+
     /**
      * @param ConfigurationLoaderInterface $configurationFileLoader
+     * @param PhpDocAnalyzer $phpDocAnalyzer
      */
-    public function __construct(ConfigurationLoaderInterface $configurationFileLoader)
+    public function __construct(ConfigurationLoaderInterface $configurationFileLoader, PhpDocAnalyzer $phpDocAnalyzer)
     {
         $this->excludedClassMethodsList = $configurationFileLoader->load();
+        $this->phpDocAnalyzer = $phpDocAnalyzer;
     }
 
     /**
@@ -51,6 +57,11 @@ class UseTypedReturnForNewMethodsRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         if ($node->isMagic()) {
+            return [];
+        }
+        
+        $docComment = $node->getDocComment();
+        if (null !== $docComment && $this->phpDocAnalyzer->containsInheritDocTag($docComment)) {
             return [];
         }
 

--- a/tests/Data/UseTypeHintForNewMethods/MethodWithInheritPhpDoc.php
+++ b/tests/Data/UseTypeHintForNewMethods/MethodWithInheritPhpDoc.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods;
+
+class MethodWithInheritPhpDoc
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function foo()
+    {
+        return;
+    }
+
+    /**
+     * Alternative with capital D
+     * {@inheritDoc}
+     */
+    public function bar()
+    {
+        return;
+    }
+}

--- a/tests/Data/UseTypedReturnForNewMethods/MethodWithInheritPhpDoc.php
+++ b/tests/Data/UseTypedReturnForNewMethods/MethodWithInheritPhpDoc.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPStanForPrestaShopTests\Data\UseTypedReturnForNewMethods;
+
+class MethodWithInheritPhpDoc
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function foo()
+    {
+        return;
+    }
+
+    /**
+     * Alternative with capital D
+     * {@inheritDoc}
+     */
+    public function bar()
+    {
+        return;
+    }
+}

--- a/tests/PhpDoc/PhpDocAnalyzerTest.php
+++ b/tests/PhpDoc/PhpDocAnalyzerTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * Copyright (c) Since 2007 PrestaShop.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PHPStanForPrestaShopTests\PhpDoc;
+
+use PhpParser\Comment\Doc;
+use PHPStanForPrestaShop\PhpDoc\PhpDocAnalyzer;
+use PHPUnit\Framework\TestCase;
+
+class PhpDocAnalyzerTest extends TestCase
+{
+    public function testEmptyComment()
+    {
+        $phpDocAnalyzer = new PhpDocAnalyzer();
+
+        $comment = new Doc('', 3, 10, 4, 6, 6, 7);
+
+        $this->assertFalse($phpDocAnalyzer->containsInheritDocTag($comment));
+    }
+
+    public function testCommentWithoutInheritDoc()
+    {
+        $phpDocAnalyzer = new PhpDocAnalyzer();
+
+        $doc = '/**
+     * @param int $a
+     */';
+        $comment = new Doc($doc, 3, 10, 4, 6, 6, 7);
+
+        $this->assertFalse($phpDocAnalyzer->containsInheritDocTag($comment));
+    }
+
+    public function testCommentWithInheritdocLowcaseD()
+    {
+        $phpDocAnalyzer = new PhpDocAnalyzer();
+
+        $doc = '/**
+     * {@inheritdoc}
+     */';
+        $comment = new Doc($doc, 3, 10, 4, 6, 6, 7);
+
+        $this->assertTrue($phpDocAnalyzer->containsInheritDocTag($comment));
+    }
+
+    public function testCommentWithInheritdocUppercaseD()
+    {
+        $phpDocAnalyzer = new PhpDocAnalyzer();
+
+        $doc = '/**
+     * {@inheritdoc}
+     */';
+        $comment = new Doc($doc, 3, 10, 4, 6, 6, 7);
+
+        $this->assertTrue($phpDocAnalyzer->containsInheritDocTag($comment));
+    }
+}

--- a/tests/Rules/UseTypeHintForNewMethodsRuleTest.php
+++ b/tests/Rules/UseTypeHintForNewMethodsRuleTest.php
@@ -13,6 +13,7 @@ namespace PHPStanForPrestaShopTests\Rules;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStanForPrestaShop\PHPConfigurationLoader\ArrayConfigurationLoader;
+use PHPStanForPrestaShop\PhpDoc\PhpDocAnalyzer;
 use PHPStanForPrestaShop\Rules\UseTypedReturnForNewMethodsRule;
 use PHPStanForPrestaShop\Rules\UseTypeHintForNewMethodsRule;
 
@@ -26,7 +27,7 @@ class UseTypeHintForNewMethodsRuleTest extends RuleTestCase
             'PHPStanForPrestaShopTests\Data\UseTypeHintForNewMethods\F::foo',
         ]);
 
-        return new UseTypeHintForNewMethodsRule($configurationLoader);
+        return new UseTypeHintForNewMethodsRule($configurationLoader, new PhpDocAnalyzer());
     }
 
     public function testRule(): void
@@ -64,5 +65,6 @@ class UseTypeHintForNewMethodsRuleTest extends RuleTestCase
             ],
         ]);
         $this->analyse([$dataDirectory . 'ClassWithConstructAndGetSet.php'], []);
+        $this->analyse([$dataDirectory . 'MethodWithInheritPhpDoc.php'], []);
     }
 }

--- a/tests/Rules/UseTypedReturnForNewMethodsRuleTest.php
+++ b/tests/Rules/UseTypedReturnForNewMethodsRuleTest.php
@@ -13,6 +13,7 @@ namespace PHPStanForPrestaShopTests\Rules;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStanForPrestaShop\PHPConfigurationLoader\ArrayConfigurationLoader;
+use PHPStanForPrestaShop\PhpDoc\PhpDocAnalyzer;
 use PHPStanForPrestaShop\Rules\UseTypedReturnForNewMethodsRule;
 
 class UseTypedReturnForNewMethodsRuleTest extends RuleTestCase
@@ -25,7 +26,7 @@ class UseTypedReturnForNewMethodsRuleTest extends RuleTestCase
             'PHPStanForPrestaShopTests\Data\UseTypedReturnForNewMethods\E::bar',
         ]);
 
-        return new UseTypedReturnForNewMethodsRule($configurationLoader);
+        return new UseTypedReturnForNewMethodsRule($configurationLoader, new PhpDocAnalyzer());
     }
 
     public function testRule(): void
@@ -53,5 +54,6 @@ class UseTypedReturnForNewMethodsRuleTest extends RuleTestCase
             ],
         ]);
         $this->analyse([$dataDirectory . 'ClassWithConstructAndGetSet.php'], []);
+        $this->analyse([$dataDirectory . 'MethodWithInheritPhpDoc.php'], []);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Handle `@inheritdoc` class methods by excluding them. See why below.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes half of https://github.com/PrestaShop/phpstan-prestashop/issues/15
| How to test?      | Ci is 😊 

## Why exclude class methods that have `{@inheritDoc}` tag?

Without this PR, when the rules UseTypeHintForNewMethodsRule and seTypedReturnForNewMethodsRule find a class method without typed parameters and type return, they consider it a violation.

When we encounter a class method with `{@inheritDoc}` though, it indicates it extends a parent method.
If parent method
- is part of the exclusion list, it's not a violation => that's already handled
- is not part of PrestaShop code, but comes from a dependency => we should not flag it as a violation

If the parent method is not part of the exclusion list and is part of PrestaShop code, the UseTypeHintForNewMethodsRule and seTypedReturnForNewMethodsRule will also find it and flag it as a violation!

So we can safely say "if this method has has `{@inheritDoc}` tag, then either the parent method tag will be flagged invalid as well or we can assume it's not a violation". This is why we can ignore them.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
