### PR TITLE
Introduce acceptance tests with phpstan PHAR

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,20 @@
+name: Acceptance tests
+on: [push, pull_request]
+jobs:
+  build:
+    strategy:
+      matrix:
+        php-versions: ['7.2','7.4']
+    runs-on: ubuntu-latest
+    name: PHPUnit
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
+
+      - run: composer install
+      - run: bash tests/Acceptance/run.sh

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Composer Install
         run: composer install --dev
       - name: Run phpstan
-        run: ./vendor/bin/phpstan analyse src tests -l 5
+        run: ./vendor/bin/phpstan analyse src tests/Rules -l 5

--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ Rules are tested using PHPStan [RuleTestCase](https://github.com/phpstan/phpstan
 
 Run static analysis with PHPStan:
 ```bash
-vendor/bin/phpstan analyse src tests -l 5
+vendor/bin/phpstan analyse src tests/Rules -l 5
+```
+
+Extension is validated using a real PHPStan phar
+```bash
+bash tests/Acceptance/run.sh
 ```
 
 ## Use in a project

--- a/tests/Acceptance/DummyApp/app.php
+++ b/tests/Acceptance/DummyApp/app.php
@@ -1,0 +1,9 @@
+<?php
+
+use PHPStanForPrestaShopTests\Acceptance\DummyApp\src\ABCD;
+
+require_once __DIR__ . '/autoload.php';
+
+$a = '';
+$b = new ABCD();
+$c = $b->getName();

--- a/tests/Acceptance/DummyApp/autoload.php
+++ b/tests/Acceptance/DummyApp/autoload.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/src/ABCD.php';

--- a/tests/Acceptance/DummyApp/src/ABCD.php
+++ b/tests/Acceptance/DummyApp/src/ABCD.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PHPStanForPrestaShopTests\Acceptance\DummyApp\src;
+
+class ABCD
+{
+    /**
+     * @return int
+     */
+    public function getName()
+    {
+        return self::class;
+    }
+}

--- a/tests/Acceptance/ValidateResult/helper.php
+++ b/tests/Acceptance/ValidateResult/helper.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @param array $reportedJSON
+ * @param int $numberExpectedErrors
+ *
+ * @throws RuntimeException if assertion is false
+ */
+function assertNumberTotalErrors(array $reportedJSON, int $numberExpectedErrors)
+{
+    $totalReportedErrors = $reportedJSON['totals']['file_errors'];
+
+    if ($totalReportedErrors !== $numberExpectedErrors) {
+        throw new RuntimeException(sprintf('Expected %d reported errors, got %d', $numberExpectedErrors, $totalReportedErrors));
+    }
+}
+
+/**
+ * @param array $reportedJSON
+ * @param string $givenFileName
+ * @param string $errorMessage
+ *
+ * @throws RuntimeException if assertion is false
+ */
+function assertFileHasErrorMessage(array $reportedJSON, string $givenFileName, string $errorMessage)
+{
+    foreach ($reportedJSON['files'] as $fileName => $fileData) {
+        if (basename($fileName) === $givenFileName) {
+            foreach ($fileData['messages'] as $errors) {
+                if ($errors['message'] === $errorMessage) {
+                    return;
+                }
+            }
+
+            throw new RuntimeException(sprintf('Could not find error message %s in given PHPStan report', $errorMessage));
+        }
+    }
+
+    throw new RuntimeException(sprintf('Could not find file %s in given PHPStan report', $fileName));
+}

--- a/tests/Acceptance/ValidateResult/validatePHPStanOutput.php
+++ b/tests/Acceptance/ValidateResult/validatePHPStanOutput.php
@@ -1,0 +1,17 @@
+<?php
+
+if ($argc !== 2) {
+    exit('Usage: php ValidateResult/validatePHPStanOutput.php {my-json}');
+}
+
+require_once __DIR__ . '/helper.php';
+
+$reportedJSON = json_decode($argv[1], true);
+
+assertNumberTotalErrors($reportedJSON, 1);
+
+assertFileHasErrorMessage(
+    $reportedJSON,
+    'ABCD.php',
+    "Method PHPStanForPrestaShopTests\\Acceptance\\DummyApp\\src\\ABCD::getName() should return int but returns string."
+);

--- a/tests/Acceptance/phpstan.neon
+++ b/tests/Acceptance/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: 4
+    bootstrapFiles:
+        - DummyApp/autoload.php
+    paths:
+        - src

--- a/tests/Acceptance/run.sh
+++ b/tests/Acceptance/run.sh
@@ -2,11 +2,11 @@
 
 echo "Running PHPStan 0.12.81 against dummy app..."
 
-phpstan_output=$(php phpstan_0.12.81.phar analyse DummyApp/ --error-format=json)
+phpstan_output=$(php tests/Acceptance/phpstan_0.12.81.phar analyse tests/Acceptance/DummyApp/ --error-format=json -l 5)
 
 echo "Validate PHPStan report..."
 
-php ValidateResult/validatePHPStanOutput.php "$phpstan_output"
+php tests/Acceptance/ValidateResult/validatePHPStanOutput.php "$phpstan_output"
 
 echo "No issues reported!"
 

--- a/tests/Acceptance/run.sh
+++ b/tests/Acceptance/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Running PHPStan 0.12.81 against dummy app..."
+
+phpstan_output=$(php phpstan_0.12.81.phar analyse DummyApp/ --error-format=json)
+
+echo "Validate PHPStan report..."
+
+php ValidateResult/validatePHPStanOutput.php "$phpstan_output"
+
+echo "No issues reported!"
+
+exit 0;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Introduce acceptance tests with phpstan PHAR. This test runs phpstan PHAR archive against a given application and validates the JSON report.<br/><br/>When this PR is merged, I will submit another that will add the extension into the acceptance test configuration and use it to reproduce bugs like https://github.com/PrestaShop/phpstan-prestashop/issues/20.<br/><br/>Also it is nice to have acceptance tests 😁  for example I would have catched bug https://github.com/PrestaShop/phpstan-prestashop/commit/234540cdc88162ff455af8c6c20cd77381841db4 sooner if I had these tests.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to https://github.com/PrestaShop/phpstan-prestashop/issues/20
| How to test?      | New GitHub Action check passes
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
