### PR TITLE
Ignore traits for UseTypeHintForNewMethodsRule and UseTypedReturnForNewMethodsRule

### DIFF
--- a/src/Rules/UseTypeHintForNewMethodsRule.php
+++ b/src/Rules/UseTypeHintForNewMethodsRule.php
@@ -59,6 +59,9 @@ class UseTypeHintForNewMethodsRule implements Rule
         if ($node->isMagic()) {
             return [];
         }
+        if ($scope->isInTrait()) {
+            return [];
+        }
 
         $docComment = $node->getDocComment();
         if (null !== $docComment && $this->phpDocAnalyzer->containsInheritDocTag($docComment)) {

--- a/src/Rules/UseTypedReturnForNewMethodsRule.php
+++ b/src/Rules/UseTypedReturnForNewMethodsRule.php
@@ -59,7 +59,10 @@ class UseTypedReturnForNewMethodsRule implements Rule
         if ($node->isMagic()) {
             return [];
         }
-        
+        if ($scope->isInTrait()) {
+            return [];
+        }
+
         $docComment = $node->getDocComment();
         if (null !== $docComment && $this->phpDocAnalyzer->containsInheritDocTag($docComment)) {
             return [];

--- a/tests/Acceptance/ValidateResult/validatePHPStanOutput.php
+++ b/tests/Acceptance/ValidateResult/validatePHPStanOutput.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/helper.php';
 
 $reportedJSON = json_decode($argv[1], true);
 
-assertNumberTotalErrors($reportedJSON, 7);
+assertNumberTotalErrors($reportedJSON, 5);
 
 assertFileHasErrorMessage(
     $reportedJSON,
@@ -41,15 +41,3 @@ assertFileHasErrorMessage(
     17
 );
 
-assertFileHasErrorMessage(
-    $reportedJSON,
-    'BadTrait.php (in context of class DummyApp\ABCD)',
-    'Every parameter of function whatCouldGoWrong should be type hinted (untyped parameters: a).',
-    7
-);
-assertFileHasErrorMessage(
-    $reportedJSON,
-    'BadTrait.php (in context of class DummyApp\ABCD)',
-    'Function whatCouldGoWrong should declare return type.',
-    7
-);


### PR DESCRIPTION
…ewMethodsRule

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Ignore traits for UseTypeHintForNewMethodsRule and UseTypedReturnForNewMethodsRule as they are handled in an exotic way that reduces quality of treport
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/phpstan-prestashop/issues/26
| How to test?      | Tests should pass

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
