### PR TITLE
Update dependencies to make it php81 compatible

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        php-versions: ['7.2','7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
     runs-on: ubuntu-latest
     name: PHPUnit
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor/
+tests/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     }
   ],
   "require": {
-    "php": "^7.1",
-    "phpstan/phpstan": "^0.12.48"
+    "php": "^7.2|^8.0",
+    "phpstan/phpstan": "^1.2.0"
   },
   "require-dev": {
-    "phpstan/phpstan-phpunit": "^0.12.16",
-    "phpstan/phpstan-strict-rules": "^0.12.5",
-    "phpunit/phpunit": "^7.5.20",
+    "phpstan/phpstan-phpunit": "^1.0.0",
+    "phpstan/phpstan-strict-rules": "^1.1.0",
+    "phpunit/phpunit": "^8.5",
     "symfony/console": "^5.2",
     "nikic/php-parser": "^4.10"
   },


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR aims to give support of php 8.0 & 8.1.
| Type?             | improvement
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI should be green
| Possible impacts? | 

### BC break
This PR brings a BC break on the minimum version of PHP supported (dropping 7.1). However, PHP 7.1 was already dropped from the CI

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
